### PR TITLE
Changed the GetField method on ODocument to not save the default valu…

### DIFF
--- a/src/OrientDB-Net.binary.Innov8tive/API/Types/ODocument.cs
+++ b/src/OrientDB-Net.binary.Innov8tive/API/Types/ODocument.cs
@@ -202,7 +202,11 @@ namespace Orient.Client
             }
 
             var result = type.GetTypeInfo().IsPrimitive || type == typeof(string) || type.IsArray ? default(T) : (T)Activator.CreateInstance(type);
-            return SaveAndReturnValue<T>(fieldPath, result);
+            // if the key wasn't in the dictionary, then return the default, but don't add the key to the dictionary unless the type is a collection.
+            if (ImplementsIList(type) || type.IsGenericType && type.GetGenericTypeDefinition() == typeof(HashSet<>))
+                return SaveAndReturnValue<T>(fieldPath, result);
+            else
+                return result;
         }
 
         private T SaveAndReturnValue<T>(string fieldPath, Object fieldValue)


### PR DESCRIPTION
…e back to the dictionary for a field that did not previously exist, unless the requested type of the field implements IList or is a HashSet.