### PR TITLE
.NET driver can't create records in multi-master replicated database

### DIFF
--- a/src/OrientDB-Net.binary.Innov8tive/Protocol/Operations/RecordCreate.cs
+++ b/src/OrientDB-Net.binary.Innov8tive/Protocol/Operations/RecordCreate.cs
@@ -30,7 +30,6 @@ namespace Orient.Client.Protocol.Operations
 
             if (_document.ORID == null)
             {
-                var clusterId = _database.GetClusterIdFor(_document.OClassName);
                 _document.ORID = new ORID(-1, -1);
             }
 

--- a/src/OrientDB-Net.binary.Innov8tive/Protocol/Operations/RecordCreate.cs
+++ b/src/OrientDB-Net.binary.Innov8tive/Protocol/Operations/RecordCreate.cs
@@ -31,7 +31,7 @@ namespace Orient.Client.Protocol.Operations
             if (_document.ORID == null)
             {
                 var clusterId = _database.GetClusterIdFor(_document.OClassName);
-                _document.ORID = new ORID(clusterId, -1);
+                _document.ORID = new ORID(-1, -1);
             }
 
             if (OClient.ProtocolVersion < 24)


### PR DESCRIPTION
This change solves the issue of "Local node 'Node1' is not the owner for cluster 'v' (it is 'Node2')" when hosting a database on more than one server with multi-master replication. (JIRA SM-248)  This solution was identified by Colin Leister from OrientDB.